### PR TITLE
Add permission for restricting the use of the application

### DIFF
--- a/backend/StreamServerApp/apps.py
+++ b/backend/StreamServerApp/apps.py
@@ -1,5 +1,17 @@
 from django.apps import AppConfig
+from rest_framework.permissions import BasePermission
 
 
 class StreamserverappConfig(AppConfig):
     name = 'StreamServerApp'
+
+
+class IsStaff(BasePermission):
+    """ Permission used for all views
+    We check if the api user is staff for granting permission.
+    """
+    def has_permission(self, request, view):
+        if hasattr(request, 'api_user'):
+            return request.api_user.is_staff
+        else:
+            return False

--- a/backend/StreamServerApp/views/videos.py
+++ b/backend/StreamServerApp/views/videos.py
@@ -1,7 +1,6 @@
 from django.shortcuts import render
 from django.conf import settings
 from rest_framework import viewsets, generics
-from rest_framework.permissions import IsAuthenticated
 
 from StreamServerApp.serializers.videos import VideoSerializer, \
      SeriesSerializer, MoviesSerializer, SeriesListSerializer, VideoListSerializer

--- a/backend/StreamingServer/middleware.py
+++ b/backend/StreamingServer/middleware.py
@@ -11,7 +11,10 @@ class UserAuthMiddleware(object):
         if request.method == 'GET':
             user_token = request.headers.get('Authorization')
         elif request.method == 'POST':
-            user_token = json.loads(request.body.decode()).get('headers', {}).get('Authorization')
+            try:
+                user_token = json.loads(request.body.decode()).get('headers', {}).get('Authorization')
+            except json.decoder.JSONDecodeError:
+                user_token = None
 
         try:
             if user_token:

--- a/backend/StreamingServer/settings.py
+++ b/backend/StreamingServer/settings.py
@@ -178,7 +178,12 @@ CORS_ALLOW_CREDENTIALS = False
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
      # the page size must be greater (strictly) than SLIDES_OF_CAROUSEL in VideoCarouselSlick.js
-    'PAGE_SIZE': 10
+    'PAGE_SIZE': 10,
+
+    # We set IsStaff as a default permission for all views
+    'DEFAULT_PERMISSION_CLASSES': [
+        'StreamServerApp.apps.IsStaff',
+    ]
 }
 
 # https://django-rest-auth.readthedocs.io/en/latest/installation.html#registration-optional


### PR DESCRIPTION
This PR aims at adding restriction of use of the app. With this change, all users would need to be staff to be able to use the application. The staff status can be set by the admin on the Django admin page. 